### PR TITLE
Command.py -> pin correct cadquery-ocp 7.8.1.1.post1 for build123d

### DIFF
--- a/CQGui/Command.py
+++ b/CQGui/Command.py
@@ -73,7 +73,7 @@ class Build123DInstall:
         import subprocess
         print("Starting to install Build123d...")
         subprocess.run(["python", "-m", "pip", "install", "--upgrade", "build123d"], capture_output=False)
-        subprocess.run(["python", "-m", "pip", "install", "--upgrade", "cadquery-ocp==7.7.2"], capture_output=False)
+        subprocess.run(["python", "-m", "pip", "install", "--upgrade", "cadquery-ocp==7.8.1.1.post1"], capture_output=False)
         print("Build123d has been installed! Please restart FreeCAD.")
 
 


### PR DESCRIPTION
build123d 0.9+depends on cadquery-ocp 7.8, so the current install was breaking the dep by installing an incompatible version. I did not touch the cadquery deps.